### PR TITLE
Add attr_reader to genre, author & label

### DIFF
--- a/item.rb
+++ b/item.rb
@@ -2,6 +2,7 @@ require 'date'
 
 class Item
   attr_accessor :publish_date
+  attr_reader :genre, :author, :label
 
   def initialize(id, publish_date, archived: false)
     @id = id


### PR DESCRIPTION
In our class 'Item' we need readers for genre, author and label.